### PR TITLE
Remove spell_known attribute from spellcasting section of cleric levels #352

### DIFF
--- a/src/5e-SRD-Levels.json
+++ b/src/5e-SRD-Levels.json
@@ -1340,7 +1340,6 @@
     ],
     "spellcasting": {
       "cantrips_known": 3,
-      "spells_known": 4,
       "spell_slots_level_1": 2,
       "spell_slots_level_2": 0,
       "spell_slots_level_3": 0,
@@ -1382,7 +1381,6 @@
     ],
     "spellcasting": {
       "cantrips_known": 3,
-      "spells_known": 5,
       "spell_slots_level_1": 3,
       "spell_slots_level_2": 0,
       "spell_slots_level_3": 0,
@@ -1419,7 +1417,6 @@
     ],
     "spellcasting": {
       "cantrips_known": 3,
-      "spells_known": 6,
       "spell_slots_level_1": 4,
       "spell_slots_level_2": 2,
       "spell_slots_level_3": 0,
@@ -1456,7 +1453,6 @@
     ],
     "spellcasting": {
       "cantrips_known": 4,
-      "spells_known": 7,
       "spell_slots_level_1": 4,
       "spell_slots_level_2": 3,
       "spell_slots_level_3": 0,
@@ -1498,7 +1494,6 @@
     ],
     "spellcasting": {
       "cantrips_known": 4,
-      "spells_known": 8,
       "spell_slots_level_1": 4,
       "spell_slots_level_2": 3,
       "spell_slots_level_3": 2,
@@ -1535,7 +1530,6 @@
     ],
     "spellcasting": {
       "cantrips_known": 4,
-      "spells_known": 9,
       "spell_slots_level_1": 4,
       "spell_slots_level_2": 3,
       "spell_slots_level_3": 3,
@@ -1572,7 +1566,6 @@
     ],
     "spellcasting": {
       "cantrips_known": 4,
-      "spells_known": 10,
       "spell_slots_level_1": 4,
       "spell_slots_level_2": 3,
       "spell_slots_level_3": 3,
@@ -1614,7 +1607,6 @@
     ],
     "spellcasting": {
       "cantrips_known": 4,
-      "spells_known": 11,
       "spell_slots_level_1": 4,
       "spell_slots_level_2": 3,
       "spell_slots_level_3": 3,
@@ -1651,7 +1643,6 @@
     ],
     "spellcasting": {
       "cantrips_known": 4,
-      "spells_known": 12,
       "spell_slots_level_1": 4,
       "spell_slots_level_2": 3,
       "spell_slots_level_3": 3,
@@ -1688,7 +1679,6 @@
     ],
     "spellcasting": {
       "cantrips_known": 5,
-      "spells_known": 14,
       "spell_slots_level_1": 4,
       "spell_slots_level_2": 3,
       "spell_slots_level_3": 3,
@@ -1725,7 +1715,6 @@
     ],
     "spellcasting": {
       "cantrips_known": 5,
-      "spells_known": 15,
       "spell_slots_level_1": 4,
       "spell_slots_level_2": 3,
       "spell_slots_level_3": 3,
@@ -1762,7 +1751,6 @@
     ],
     "spellcasting": {
       "cantrips_known": 5,
-      "spells_known": 15,
       "spell_slots_level_1": 4,
       "spell_slots_level_2": 3,
       "spell_slots_level_3": 3,
@@ -1793,7 +1781,6 @@
     "features": [],
     "spellcasting": {
       "cantrips_known": 5,
-      "spells_known": 16,
       "spell_slots_level_1": 4,
       "spell_slots_level_2": 3,
       "spell_slots_level_3": 3,
@@ -1830,7 +1817,6 @@
     ],
     "spellcasting": {
       "cantrips_known": 5,
-      "spells_known": 18,
       "spell_slots_level_1": 4,
       "spell_slots_level_2": 3,
       "spell_slots_level_3": 3,
@@ -1861,7 +1847,6 @@
     "features": [],
     "spellcasting": {
       "cantrips_known": 5,
-      "spells_known": 19,
       "spell_slots_level_1": 4,
       "spell_slots_level_2": 3,
       "spell_slots_level_3": 3,
@@ -1898,7 +1883,6 @@
     ],
     "spellcasting": {
       "cantrips_known": 5,
-      "spells_known": 19,
       "spell_slots_level_1": 4,
       "spell_slots_level_2": 3,
       "spell_slots_level_3": 3,
@@ -1935,7 +1919,6 @@
     ],
     "spellcasting": {
       "cantrips_known": 5,
-      "spells_known": 20,
       "spell_slots_level_1": 4,
       "spell_slots_level_2": 3,
       "spell_slots_level_3": 3,
@@ -1972,7 +1955,6 @@
     ],
     "spellcasting": {
       "cantrips_known": 5,
-      "spells_known": 22,
       "spell_slots_level_1": 4,
       "spell_slots_level_2": 3,
       "spell_slots_level_3": 3,
@@ -2009,7 +1991,6 @@
     ],
     "spellcasting": {
       "cantrips_known": 5,
-      "spells_known": 22,
       "spell_slots_level_1": 4,
       "spell_slots_level_2": 3,
       "spell_slots_level_3": 3,
@@ -2046,7 +2027,6 @@
     ],
     "spellcasting": {
       "cantrips_known": 5,
-      "spells_known": 22,
       "spell_slots_level_1": 4,
       "spell_slots_level_2": 3,
       "spell_slots_level_3": 3,


### PR DESCRIPTION
## What does this do?
remove spells_known attribute for clerics as mentioned in #352