### PR TITLE
Update hand crossbows proficiency name to be consistent with proficiency lists in the SRD. #349

### DIFF
--- a/src/5e-SRD-Classes.json
+++ b/src/5e-SRD-Classes.json
@@ -378,9 +378,9 @@
         "url": "/api/proficiencies/shortswords"
       },
       {
-        "index": "crossbows-hand",
-        "name": "Crossbows, hand",
-        "url": "/api/proficiencies/crossbows-hand"
+        "index": "hand-crossbows",
+        "name": "Hand Crossbows",
+        "url": "/api/proficiencies/hand-crossbows"
       }
     ],
     "saving_throws": [
@@ -2653,9 +2653,9 @@
         "url": "/api/proficiencies/shortswords"
       },
       {
-        "index": "crossbows-hand",
-        "name": "Crossbows, hand",
-        "url": "/api/proficiencies/crossbows-hand"
+        "index": "hand-crossbows",
+        "name": "Hand Crossbows",
+        "url": "/api/proficiencies/hand-crossbows"
       },
       {
         "index": "thieves-tools",

--- a/src/5e-SRD-Classes.json
+++ b/src/5e-SRD-Classes.json
@@ -379,7 +379,7 @@
       },
       {
         "index": "hand-crossbows",
-        "name": "Hand Crossbows",
+        "name": "Hand crossbows",
         "url": "/api/proficiencies/hand-crossbows"
       }
     ],
@@ -2654,7 +2654,7 @@
       },
       {
         "index": "hand-crossbows",
-        "name": "Hand Crossbows",
+        "name": "Hand crossbows",
         "url": "/api/proficiencies/hand-crossbows"
       },
       {

--- a/src/5e-SRD-Proficiencies.json
+++ b/src/5e-SRD-Proficiencies.json
@@ -1178,9 +1178,9 @@
     ]
   },
   {
-    "index": "crossbows-hand",
+    "index": "hand-crossbows",
     "type": "Weapons",
-    "name": "Crossbows, hand",
+    "name": "Hand crossbows",
     "classes": [
       {
         "index": "bard",

--- a/src/5e-SRD-Proficiencies.json
+++ b/src/5e-SRD-Proficiencies.json
@@ -1194,7 +1194,7 @@
       }
     ],
     "races": [],
-    "url": "/api/proficiencies/crossbows-hand",
+    "url": "/api/proficiencies/hand-crossbows",
     "references": [
       {
         "index": "crossbow-hand",


### PR DESCRIPTION
## What does this do?
Update hand crossbows proficiency name to be consistent with proficiency lists in the SRD. #349
